### PR TITLE
Fix duplicate voice event listener in speechService

### DIFF
--- a/js/speechService.js
+++ b/js/speechService.js
@@ -32,8 +32,16 @@ export class SpeechService {
                 cb();
             }
         };
+
+        if (this.enVoice) {
+            cb();
+            return;
+        }
+
         load();
-        this.synth.addEventListener('voiceschanged', load);
+        if (!this.enVoice) {
+            this.synth.addEventListener('voiceschanged', load);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid adding multiple `voiceschanged` listeners in `speechService`

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68404ab23a3c8327bd5b352c5e01de95