### PR TITLE
Add React-based sample sentences page

### DIFF
--- a/src/data/samples.json
+++ b/src/data/samples.json
@@ -1,0 +1,44 @@
+{
+  "business": {
+    "beginner": [
+      "Let's schedule a meeting for tomorrow.",
+      "Could you send me the report by noon?"
+    ],
+    "intermediate": [
+      "Our quarterly earnings have exceeded expectations.",
+      "We need to streamline the approval process."
+    ],
+    "advanced": [
+      "The merger negotiations are proceeding smoothly despite the setbacks.",
+      "Our strategic outlook requires a comprehensive market analysis."
+    ]
+  },
+  "travel": {
+    "beginner": [
+      "Where is the nearest train station?",
+      "I'd like a ticket to Tokyo, please."
+    ],
+    "intermediate": [
+      "How long does the sightseeing bus tour take?",
+      "Is breakfast included with the room?"
+    ],
+    "advanced": [
+      "Could you recommend some hidden gems that locals love?",
+      "I'm interested in understanding the cultural significance of this festival."
+    ]
+  },
+  "daily": {
+    "beginner": [
+      "How's the weather today?",
+      "I'm going to the supermarket."
+    ],
+    "intermediate": [
+      "What do you usually do on weekends?",
+      "I'm thinking about starting a new hobby."
+    ],
+    "advanced": [
+      "It's important to balance work and personal life for mental well-being.",
+      "Could you share your thoughts on sustainable living?"
+    ]
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -49,6 +49,9 @@
 
         </ul>
       </div>
+      <div class="text-end mt-3">
+        <a href="samples.html" class="btn btn-link">サンプル例文一覧</a>
+      </div>
     </div>
   </main>
   <script type="module" src="js/main.js"></script>

--- a/src/samples.html
+++ b/src/samples.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>サンプル例文</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="container py-4">
+  <div id="root"></div>
+  <script type="text/babel" data-presets="react">
+    function App() {
+      const [data, setData] = React.useState({});
+      const [situation, setSituation] = React.useState('business');
+      const [level, setLevel] = React.useState('beginner');
+
+      React.useEffect(() => {
+        fetch('data/samples.json')
+          .then(res => res.json())
+          .then(setData);
+      }, []);
+
+      const situations = Object.keys(data);
+      const levels = ['beginner', 'intermediate', 'advanced'];
+
+      const sentences = data[situation]?.[level] || [];
+
+      return (
+        <div>
+          <h1 className="mb-3">サンプル例文</h1>
+          <div className="row mb-3">
+            <div className="col-auto">
+              <select className="form-select" value={situation} onChange={e => setSituation(e.target.value)}>
+                {situations && situations.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+            <div className="col-auto">
+              <select className="form-select" value={level} onChange={e => setLevel(e.target.value)}>
+                {levels.map(l => <option key={l} value={l}>{l}</option>)}
+              </select>
+            </div>
+          </div>
+          <ul className="list-group">
+            {sentences.map((t, idx) => <li key={idx} className="list-group-item">{t}</li>)}
+          </ul>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a JSON file to manage sample sentences
- create a React page to select situation and level
- link new sample page from the main index

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68443f7755708327896afc4d78e397ce